### PR TITLE
Fix harmonic mean zero case

### DIFF
--- a/src/utils/formulas.test.ts
+++ b/src/utils/formulas.test.ts
@@ -21,6 +21,15 @@ describe('calculateScore', () => {
     expect(result).toBeCloseTo(2.6666, 3);
   });
 
+  it('returns 0 for harmonic mean when any signal is zero', () => {
+    const signals: Signal[] = [
+      { id: '1', name: 'A', value: 0, weight: 1, isFormula: false },
+      { id: '2', name: 'B', value: 0.5, weight: 1, isFormula: false }
+    ];
+    const result = calculateScore('harmonicMean', signals);
+    expect(result).toBe(0);
+  });
+
   it('calculates probabilistic OR correctly', () => {
     const signals: Signal[] = [
       { id: '1', name: 'A', value: 0.5, weight: 1, isFormula: false },

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -29,11 +29,19 @@ function weightedArithmeticMean(signals: Signal[]): number {
   return weightedSum / totalWeight;
 }
 function weightedHarmonicMean(signals: Signal[]): number {
-  const validSignals = signals.filter(signal => signal.value > 0);
-  if (validSignals.length === 0) return 0;
-  const totalWeight = validSignals.reduce((acc, signal) => acc + signal.weight, 0);
+  const totalWeight = signals.reduce((acc, signal) => acc + signal.weight, 0);
   if (totalWeight === 0) return 0;
-  const weightedReciprocalSum = validSignals.reduce((acc, signal) => acc + signal.weight / signal.value, 0);
+
+  // If any positively weighted signal has a value of 0 or less,
+  // the harmonic mean should be 0.
+  if (signals.some(signal => signal.weight > 0 && signal.value <= 0)) {
+    return 0;
+  }
+
+  const weightedReciprocalSum = signals.reduce(
+    (acc, signal) => acc + signal.weight / signal.value,
+    0
+  );
   return totalWeight / weightedReciprocalSum;
 }
 function weightedProbabilisticOr(signals: Signal[]): number {


### PR DESCRIPTION
## Summary
- handle zero-valued signals in the weighted harmonic mean calculation
- test harmonic mean behaviour with zero input

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68406c40e3ec832ea6d26892a43f3859